### PR TITLE
Add minimum order amount settings

### DIFF
--- a/addon/templates/networks/index/network/index.hbs
+++ b/addon/templates/networks/index/network/index.hbs
@@ -176,6 +176,23 @@
                     {{/if}}
                 </div>
                 <div class="input-group">
+                    <Toggle @isToggled={{@model.options.required_checkout_min}} @onToggle={{fn (mut @model.options.required_checkout_min)}}>
+                        <FaIcon @icon="dollar-sign" class="text-gray-600 dark:text-gray-400 mx-2" /><span class="dark:text-gray-100 text-sm">{{t
+                                "storefront.networks.index.network.index.general-network-settings-form.config-switches.enable-minimum-order-amount"
+                            }}</span>
+                    </Toggle>
+                    {{#if @model.options.required_checkout_min}}
+                        <MoneyInput
+                            @wrapperClass="mb-0 mt-2"
+                            @name={{t "storefront.networks.index.network.index.general-network-settings-form.config-switches.minimum-order-amount-input-label"}}
+                            @value={{@model.options.required_checkout_min_amount}}
+                            @currency={{@model.currency}}
+                            @onChange={{fn (mut @model.options.required_checkout_min_amount)}}
+                            @helpText={{t "storefront.networks.index.network.index.general-network-settings-form.config-switches.minimum-order-amount-input-help-text"}}
+                        />
+                    {{/if}}
+                </div>
+                <div class="input-group">
                     <Toggle @isToggled={{@model.options.auto_accept_orders}} @onToggle={{fn (mut @model.options.auto_accept_orders)}}>
                         <FaIcon @icon="robot" class="text-gray-600 dark:text-gray-400 mx-2" /><span class="dark:text-gray-100 text-sm">{{t
                                 "storefront.networks.index.network.index.general-network-settings-form.config-switches.auto-accept-incoming-orders"

--- a/addon/templates/settings/index.hbs
+++ b/addon/templates/settings/index.hbs
@@ -255,6 +255,23 @@
                             {{/if}}
                         </div>
                         <div class="input-group">
+                            <Toggle @isToggled={{@model.options.required_checkout_min}} @onToggle={{fn (mut @model.options.required_checkout_min)}}>
+                                <FaIcon @icon="dollar-sign" class="text-gray-600 dark:text-gray-400 mx-2" /><span class="dark:text-gray-100 text-sm">{{t
+                                        "storefront.settings.index.enable-minimum-order-amount"
+                                    }}</span>
+                            </Toggle>
+                            {{#if @model.options.required_checkout_min}}
+                                <MoneyInput
+                                    @wrapperClass="mb-0 mt-2"
+                                    @name={{t "storefront.settings.index.minimum-order-amount"}}
+                                    @value={{@model.options.required_checkout_min_amount}}
+                                    @currency={{@model.currency}}
+                                    @onChange={{fn (mut @model.options.required_checkout_min_amount)}}
+                                    @helpText={{t "storefront.settings.index.minimum-order-amount-help-text"}}
+                                />
+                            {{/if}}
+                        </div>
+                        <div class="input-group">
                             <Toggle @isToggled={{@model.options.auto_accept_orders}} @onToggle={{fn (mut @model.options.auto_accept_orders)}}>
                                 <FaIcon @icon="robot" class="text-gray-600 dark:text-gray-400 mx-2" /><span class="dark:text-gray-100 text-sm">{{t
                                         "storefront.settings.index.auto-accept-incoming-order"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -369,6 +369,9 @@ storefront:
               enable-tax: Enable tax
               tax-percentage-input-label: Tax Percentage
               tax-percentage-input-help-text: The sales tax percentage to apply to orders.
+              enable-minimum-order-amount: Enable minimum order amount
+              minimum-order-amount-input-label: Minimum Order Amount
+              minimum-order-amount-input-help-text: The minimum order amount required for checkout.
               auto-accept-incoming-orders: Auto accept incoming orders
               auto-dispatch-orders: Auto dispatch orders
               require-proof-of-delivery: Require proof of delivery
@@ -610,6 +613,9 @@ storefront:
       enable-tax: Enable tax
       tax-percentage: Tax Percentage
       tax-percentage-help-text: The sales tax percentage to apply to orders.
+      enable-minimum-order-amount: Enable minimum order amount
+      minimum-order-amount: Minimum Order Amount
+      minimum-order-amount-help-text: The minimum order amount required for checkout.
       auto-accept-incoming-order: Auto accept incoming orders
       auto-dispatch-order: Auto dispatch orders
       require-proof-of-delivery: Require proof of delivery


### PR DESCRIPTION
This PR adds minimum order amount settings to both store and network configurations.

## Changes
- Added `required_checkout_min` toggle setting to enable/disable minimum order amount requirement
- Added `required_checkout_min_amount` MoneyInput field for setting the minimum amount
- Settings are positioned after the tax configuration in both:
  - Store settings (`addon/templates/settings/index.hbs`)
  - Network settings (`addon/templates/networks/index/network/index.hbs`)
- MoneyInput field only displays when the toggle is enabled
- Uses the store/network currency for proper formatting

## Implementation Details
- The toggle uses `@model.options.required_checkout_min` for the enabled state
- The amount input uses `@model.options.required_checkout_min_amount` for the value
- MoneyInput component properly handles currency formatting based on `@model.currency`
- Follows the same pattern as the existing tax settings for consistency