### PR TITLE
Fix storefront customer signup creation

### DIFF
--- a/server/src/Http/Controllers/v1/CustomerController.php
+++ b/server/src/Http/Controllers/v1/CustomerController.php
@@ -199,12 +199,14 @@ class CustomerController extends Controller
             // create the user
             $user = User::create(array_merge(
                 [
-                    'type'         => 'customer',
                     'company_uuid' => session('company'),
                     'phone'        => static::phone($request->input('phone')),
                 ],
-                $request->only(['name', 'type', 'email', 'phone', 'meta'])
+                $request->only(['name', 'email', 'phone', 'meta'])
             ));
+            $user->setUserType('customer');
+        } elseif (!$user->type) {
+            $user->setUserType('customer');
         }
 
         // always customer type
@@ -239,14 +241,20 @@ class CustomerController extends Controller
         }
 
         // create the customer/contact
-        try {
-            $customer = Contact::create($input);
-        } catch (UserAlreadyExistsException $e) {
-            // If the exception is thrown because user already exists and
-            // that user is the same user already assigned continue
-            $customer = Contact::where(['company_uuid' => session('company'), 'phone' => $input['phone']])->first();
-        } catch (\Exception $e) {
-            return response()->apiError($e->getMessage());
+        $customer = Contact::where(['company_uuid' => session('company'), 'user_uuid' => $user->uuid, 'type' => 'customer'])->first();
+        if (!$customer) {
+            try {
+                $customer = Contact::create($input);
+            } catch (UserAlreadyExistsException $e) {
+                // If the exception is thrown because user already exists and
+                // that user is the same user already assigned continue
+                $customer = Contact::where(['company_uuid' => session('company'), 'user_uuid' => $user->uuid, 'type' => 'customer'])->first();
+                if (!$customer) {
+                    return response()->apiError($e->getMessage());
+                }
+            } catch (\Exception $e) {
+                return response()->apiError($e->getMessage());
+            }
         }
 
         // generate auth token


### PR DESCRIPTION
## Summary
- ensure Storefront signup persists customer user type outside guarded mass assignment
- reuse existing customer contacts by company/user/type before creating a new contact
- return the identity conflict error instead of dereferencing a null customer after ContactObserver rejects creation

## Root cause
Storefront attempted to mass-assign `users.type = customer`, but `type` is guarded on the core User model. Contact creation then triggered FleetOps customer identity validation and could throw `UserAlreadyExistsException`; Storefront recovered by looking up a contact by phone only, which could return null and crash at `$customer->uuid`.

## Validation
- `php -l server/src/Http/Controllers/v1/CustomerController.php`
- `git diff --check`

## Notes
- Package Composer scripts were not run because this checkout does not have package-local `server_vendor/bin` or monorepo `vendor/bin` installed.
- No documentation or API specification changes are needed; the request/response contract is unchanged.